### PR TITLE
Refine layout for single-screen experience

### DIFF
--- a/src/app/_components/GameBoard.tsx
+++ b/src/app/_components/GameBoard.tsx
@@ -19,8 +19,8 @@ export default function GameBoard() {
 
   if (gameState === 'idle') {
     return (
-      <div className="w-full max-w-4xl mx-auto px-4">
-        <div className="nintendo-card text-center space-y-4 md:space-y-6 lg:space-y-8">
+      <div className="w-full h-full flex items-center justify-center px-4">
+        <div className="nintendo-card w-full max-w-4xl text-center space-y-4 md:space-y-6 lg:space-y-8">
           {/* Hero Section */}
           <div className="space-y-3 md:space-y-4 lg:space-y-6">
             <h2 className="text-display-lg md:text-display-hero text-white font-bold leading-tight">
@@ -30,9 +30,9 @@ export default function GameBoard() {
               Compare facts across cities and states. Can you guess which location has more?
             </p>
           </div>
-          
+
           {/* Category Grid */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 lg:gap-6 py-4 md:py-6 lg:py-8 mb-6 md:mb-8">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4 lg:gap-6 py-2 md:py-4 lg:py-6 mb-4 md:mb-6">
             <div className="category-chip">
               <span className="category-chip-icon">👥</span>
               <span>Population</span>
@@ -77,9 +77,9 @@ export default function GameBoard() {
   }
 
   return (
-    <div className="w-full space-y-4 md:space-y-6">
+    <div className="w-full h-full flex flex-col items-center justify-center space-y-4 md:space-y-6">
       <QuestionCard />
-    
+
       {gameState === 'answered' && (
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -97,4 +97,4 @@ export default function GameBoard() {
       )}
     </div>
   );
-} 
+}

--- a/src/app/_components/ShowHeader.tsx
+++ b/src/app/_components/ShowHeader.tsx
@@ -6,46 +6,24 @@ export default function ShowHeader() {
   const { gameState, score, answeredQuestions } = useGameStore();
 
   const questionsAnswered = answeredQuestions.size;
-  const accuracyPercentage = questionsAnswered > 0 ? Math.round((score / answeredQuestions.size) * 100) : 0;
+  const accuracyPercentage =
+    questionsAnswered > 0 ? Math.round((score / questionsAnswered) * 100) : 0;
 
   return (
-    <>
-      {/* Desktop Score Display - Top Right */}
+    <header className="flex flex-col items-center space-y-4">
+      <h1 className="logo-text text-center">Who Has More?</h1>
       {gameState !== 'idle' && (
-        <div className="score-container-separated">
-          <div className="score-item">
-            <span className="text-caption">SCORE</span>
+        <div className="flex gap-8">
+          <div className="text-center">
+            <span className="text-caption block">SCORE</span>
             <span className="text-heading-xl text-nintendo-blue">{score}</span>
           </div>
-          <div className="score-item">
-            <span className="text-caption">ACCURACY</span>
+          <div className="text-center">
+            <span className="text-caption block">ACCURACY</span>
             <span className="text-heading-xl text-nintendo-purple">{accuracyPercentage}%</span>
           </div>
         </div>
       )}
-
-      {/* Main Title with inline score info for mobile */}
-      <div className="w-full">
-        <div className="text-center">
-          <h1 className="logo-text">
-            Who Has More?
-          </h1>
-          
-          {/* Inline score display for mobile only */}
-          {gameState !== 'idle' && (
-            <div className="mobile-score-display">
-              <div className="score-inline">
-                <span className="score-label">Score:</span>
-                <span className="score-value score-blue-mobile">{score}</span>
-              </div>
-              <div className="score-inline">
-                <span className="score-label">Accuracy:</span>
-                <span className="score-value score-purple-mobile">{accuracyPercentage}%</span>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    </>
+    </header>
   );
-} 
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
 /* Import modern font pairings */
 @import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600;700&display=swap');
 
-/* Nintendo-Inspired Bright & Playful Design System */
+/* Neutral design system */
 :root {
   --nintendo-red: #e60012;
   --nintendo-blue: #0066cc;
@@ -117,14 +117,13 @@
   text-align: center;
 }
 
-/* Enhanced body styling - Static background */
+/* Layout base */
 body {
   font-family: 'Inter', sans-serif;
-  background: radial-gradient(ellipse at center, #87ceeb 0%, #4682b4 50%, #1e3a8a 100%);
-  background-attachment: fixed;
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
   min-height: 100vh;
   position: relative;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 /* Remove animated background effects - make static */
@@ -136,34 +135,17 @@ body::after {
   display: none;
 }
 
-/* Enhanced logo with better contrast */
+/* Simple logo styling */
 .logo-text {
   font-family: 'Sora', sans-serif;
-  font-size: 3rem;
-  font-weight: 900;
-  line-height: 0.9;
-  letter-spacing: -0.05em;
-  background: linear-gradient(135deg, #ffffff 0%, #f0f8ff 50%, #ffffff 100%);
-  background-size: 200% 200%;
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: transparent;
-  text-shadow: 0 0 8px rgba(255, 255, 255, 0.4), 0 2px 4px rgba(255, 255, 255, 0.3);
-  position: relative;
-  display: inline-block;
-  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.3));
+  font-size: 2.25rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--nintendo-primary-text);
 }
 
 .logo-text::after {
-  content: '';
-  position: absolute;
-  bottom: -4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 60%;
-  height: 3px;
-  background: linear-gradient(90deg, transparent, var(--nintendo-yellow), transparent);
-  border-radius: 2px;
+  content: none;
 }
 
 /* Compact score container for top-right placement */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,10 +9,10 @@ export default function Home() {
   const { showConfetti, showStarburst } = useGameStore();
 
   return (
-    <main className="min-h-screen relative">
+    <main className="h-screen flex flex-col items-center justify-center relative overflow-hidden">
       <ConfettiEffect trigger={showConfetti} type="confetti" />
       <ConfettiEffect trigger={showStarburst} type="starburst" />
-      <div className="px-4 py-4 space-y-4 md:px-6 md:py-8 md:space-y-8">
+      <div className="w-full h-full flex flex-col items-center justify-center px-4 py-4 md:px-6 md:py-8 space-y-6">
         <ShowHeader />
         <GameBoard />
       </div>


### PR DESCRIPTION
## Summary
- Center main content and confetti effects in full-screen layout so pages fit without scrolling.
- Streamline header with integrated score display and compact game board for start and question views.
- Simplify global styles with neutral background and lighter logo treatment for a professional look.

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898e02218f4832886a161bfca63b349