### PR TITLE
Refine responsive layout and styling

### DIFF
--- a/src/app/_components/GameBoard.tsx
+++ b/src/app/_components/GameBoard.tsx
@@ -32,7 +32,7 @@ export default function GameBoard() {
           </div>
           
           {/* Category Grid */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 lg:gap-6 py-4 md:py-6 lg:py-8 mb-6 md:mb-8">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 lg:gap-6 py-2 md:py-3 lg:py-4 mb-4 md:mb-6">
             <div className="category-chip">
               <span className="category-chip-icon">👥</span>
               <span>Population</span>
@@ -77,9 +77,9 @@ export default function GameBoard() {
   }
 
   return (
-    <div className="w-full space-y-4 md:space-y-6">
+    <div className="w-full max-w-4xl mx-auto px-4 flex flex-col items-center justify-center gap-4 md:gap-6">
       <QuestionCard />
-    
+
       {gameState === 'answered' && (
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -97,4 +97,4 @@ export default function GameBoard() {
       )}
     </div>
   );
-} 
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,28 +5,28 @@
 /* Import modern font pairings */
 @import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600;700&display=swap');
 
-/* Nintendo-Inspired Bright & Playful Design System */
+/* Professional, neutral design system */
 :root {
-  --nintendo-red: #e60012;
-  --nintendo-blue: #0066cc;
-  --nintendo-yellow: #ffcc00;
-  --nintendo-green: #00a652;
-  --nintendo-purple: #8b5fbf;
-  --nintendo-orange: #ff6600;
-  --nintendo-pink: #ff69b4;
-  
+  --nintendo-red: #dc2626;
+  --nintendo-blue: #2563eb;
+  --nintendo-yellow: #eab308;
+  --nintendo-green: #16a34a;
+  --nintendo-purple: #7c3aed;
+  --nintendo-orange: #f97316;
+  --nintendo-pink: #ec4899;
+
   /* Background colors */
-  --nintendo-bg-primary: #e8f4fd;
-  --nintendo-bg-secondary: #f0f8ff;
-  
+  --nintendo-bg-primary: #f8fafc;
+  --nintendo-bg-secondary: #e2e8f0;
+
   /* Text colors */
-  --nintendo-primary-text: #1a365d;
-  --nintendo-secondary-text: #4a5568;
-  --nintendo-tertiary-text: #718096;
-  
+  --nintendo-primary-text: #1f2937;
+  --nintendo-secondary-text: #4b5563;
+  --nintendo-tertiary-text: #6b7280;
+
   /* Card colors */
-  --nintendo-card-bg: rgba(255, 255, 255, 0.95);
-  --nintendo-card-border: rgba(255, 255, 255, 0.6);
+  --nintendo-card-bg: rgba(255, 255, 255, 0.9);
+  --nintendo-card-border: rgba(0, 0, 0, 0.05);
   
   /* Spacing grid - 8pt system */
   --space-1: 0.125rem; /* 2px */
@@ -120,8 +120,7 @@
 /* Enhanced body styling - Static background */
 body {
   font-family: 'Inter', sans-serif;
-  background: radial-gradient(ellipse at center, #87ceeb 0%, #4682b4 50%, #1e3a8a 100%);
-  background-attachment: fixed;
+  background: linear-gradient(to bottom right, var(--nintendo-bg-primary), var(--nintendo-bg-secondary));
   min-height: 100vh;
   position: relative;
   overflow-x: hidden;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,11 +9,11 @@ export default function Home() {
   const { showConfetti, showStarburst } = useGameStore();
 
   return (
-    <main className="min-h-screen relative">
+    <main className="h-screen flex flex-col overflow-hidden">
       <ConfettiEffect trigger={showConfetti} type="confetti" />
       <ConfettiEffect trigger={showStarburst} type="starburst" />
-      <div className="px-4 py-4 space-y-4 md:px-6 md:py-8 md:space-y-8">
-        <ShowHeader />
+      <ShowHeader />
+      <div className="flex-1 flex items-center justify-center px-4 md:px-6">
         <GameBoard />
       </div>
     </main>


### PR DESCRIPTION
## Summary
- Center content and confetti within a full-height layout to keep game on a single screen
- Tighten GameBoard spacing and center gameplay elements for better desktop/mobile fit
- Introduce neutral color palette and subtle background gradient for a more professional look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e02218f4832886a161bfca63b349