### PR TITLE
Refactor layout for cleaner full-screen design

### DIFF
--- a/src/app/_components/GameBoard.tsx
+++ b/src/app/_components/GameBoard.tsx
@@ -19,10 +19,10 @@ export default function GameBoard() {
 
   if (gameState === 'idle') {
     return (
-      <div className="w-full max-w-4xl mx-auto px-4">
-        <div className="nintendo-card text-center space-y-4 md:space-y-6 lg:space-y-8">
+      <div className="w-full max-w-3xl mx-auto">
+        <div className="nintendo-card flex flex-col items-center text-center gap-6">
           {/* Hero Section */}
-          <div className="space-y-3 md:space-y-4 lg:space-y-6">
+          <div className="space-y-2">
             <h2 className="text-display-lg md:text-display-hero text-white font-bold leading-tight">
               Test Your Knowledge
             </h2>
@@ -30,9 +30,9 @@ export default function GameBoard() {
               Compare facts across cities and states. Can you guess which location has more?
             </p>
           </div>
-          
+
           {/* Category Grid */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 lg:gap-6 py-4 md:py-6 lg:py-8 mb-6 md:mb-8">
+          <div className="grid grid-cols-4 gap-2 md:gap-4">
             <div className="category-chip">
               <span className="category-chip-icon">👥</span>
               <span>Population</span>
@@ -66,18 +66,16 @@ export default function GameBoard() {
               <span>Culture</span>
             </div>
           </div>
-          
+
           {/* Start Button Section */}
-          <div>
-            <StartButton />
-          </div>
+          <StartButton />
         </div>
       </div>
     );
   }
 
   return (
-    <div className="w-full space-y-4 md:space-y-6">
+    <div className="w-full max-w-4xl mx-auto space-y-4 md:space-y-6">
       <QuestionCard />
     
       {gameState === 'answered' && (

--- a/src/app/_components/QuestionCard.tsx
+++ b/src/app/_components/QuestionCard.tsx
@@ -242,16 +242,16 @@ export default function QuestionCard() {
   };
 
   return (
-    <div className="w-full max-w-4xl mx-auto px-4 py-3 md:py-6 relative z-10">
+    <div className="w-full max-w-4xl mx-auto p-4 relative z-10">
       {/* Question Header */}
-      <div className="text-center mb-4 md:mb-8">
+      <div className="text-center mb-4">
         <h2 className="text-question">
           {formatQuestion(question.category)}
         </h2>
       </div>
 
       {/* Answer Options */}
-      <div className="w-full mx-auto mb-4 md:mb-8" style={{maxWidth: '760px'}}>
+      <div className="w-full mx-auto mb-4" style={{maxWidth: '760px'}}>
         <div className="flex flex-col">
           {(['A', 'B'] as const).map((letter, index) => {
             const option = letter === 'A' ? question.optionA : question.optionB;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,7 +124,7 @@ body {
   background-attachment: fixed;
   min-height: 100vh;
   position: relative;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 /* Remove animated background effects - make static */
@@ -220,10 +220,10 @@ body::after {
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.7));
   border: 1px solid rgba(255, 255, 255, 0.6);
   border-radius: 20px;
-  padding: var(--space-2) var(--space-6);
+  padding: var(--space-1) var(--space-3);
   backdrop-filter: blur(8px);
   font-family: 'Inter', sans-serif;
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   color: var(--nintendo-secondary-text);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,11 +9,11 @@ export default function Home() {
   const { showConfetti, showStarburst } = useGameStore();
 
   return (
-    <main className="min-h-screen relative">
+    <main className="h-dvh w-full overflow-hidden flex flex-col">
       <ConfettiEffect trigger={showConfetti} type="confetti" />
       <ConfettiEffect trigger={showStarburst} type="starburst" />
-      <div className="px-4 py-4 space-y-4 md:px-6 md:py-8 md:space-y-8">
-        <ShowHeader />
+      <ShowHeader />
+      <div className="flex-1 flex items-center justify-center px-4">
         <GameBoard />
       </div>
     </main>


### PR DESCRIPTION
## Summary
- Center layout within dynamic viewport height to avoid scrolling
- Streamline start screen with compact category grid and reduced spacing
- Trim question card padding for tighter fit on all screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e02218f4832886a161bfca63b349