### PR TITLE
style: enhance opening game layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,10 +9,10 @@ export default function Home() {
   const { showConfetti, showStarburst } = useGameStore();
 
   return (
-    <main className="min-h-screen relative">
+    <main className="relative flex min-h-screen items-center justify-center p-4 md:p-8">
       <ConfettiEffect trigger={showConfetti} type="confetti" />
       <ConfettiEffect trigger={showStarburst} type="starburst" />
-      <div className="px-4 py-4 space-y-4 md:px-6 md:py-8 md:space-y-8">
+      <div className="w-full max-w-5xl space-y-6 rounded-3xl bg-white/30 p-6 shadow-xl backdrop-blur-lg md:space-y-10 md:p-12">
         <ShowHeader />
         <GameBoard />
       </div>


### PR DESCRIPTION
## Summary
- center game board and header within a glass-styled panel
- adjust root page layout for a more polished first impression

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e3fe9098832883dc2b17ef9190c6