### PR TITLE
feat: refresh UI with Apple Arcade styling

### DIFF
--- a/src/app/_components/GameBoard.tsx
+++ b/src/app/_components/GameBoard.tsx
@@ -20,7 +20,7 @@ export default function GameBoard() {
   if (gameState === 'idle') {
     return (
       <div className="w-full max-w-4xl mx-auto px-4">
-        <div className="nintendo-card text-center space-y-4 md:space-y-6 lg:space-y-8">
+        <div className="arcade-card text-center space-y-4 md:space-y-6 lg:space-y-8">
           {/* Hero Section */}
           <div className="space-y-3 md:space-y-4 lg:space-y-6">
             <h2 className="text-display-lg md:text-display-hero text-white font-bold leading-tight">
@@ -89,7 +89,7 @@ export default function GameBoard() {
         >
           <button
             onClick={handleNextQuestion}
-            className="nintendo-btn nintendo-btn-primary"
+            className="arcade-btn arcade-btn-primary"
           >
             Next Question
           </button>

--- a/src/app/_components/QuestionCard.tsx
+++ b/src/app/_components/QuestionCard.tsx
@@ -282,7 +282,7 @@ export default function QuestionCard() {
                     )}
                   </div>
                   <div className="flex-1 text-left">
-                    <div className="text-body-lg font-semibold text-nintendo-primary-text">
+                    <div className="text-body-lg font-semibold text-arcade-primary-text">
                       {cleanedOption}
                     </div>
                     {isAnswered && (
@@ -292,7 +292,7 @@ export default function QuestionCard() {
                         transition={{ delay: 0.3 }}
                         className="mt-2"
                       >
-                        <div className="text-small text-nintendo-secondary-text">
+                        <div className="text-small text-arcade-secondary-text">
                           Value: {option.value?.toLocaleString()} {option.unit}
                         </div>
                       </motion.div>
@@ -314,9 +314,9 @@ export default function QuestionCard() {
           className="w-full mx-auto explanation-spacing"
           style={{maxWidth: '760px'}}
         >
-          <div className="nintendo-card text-left">
+          <div className="arcade-card text-left">
             <div className="flex items-start gap-3 md:gap-4">
-              <div className="flex-shrink-0 w-8 h-8 md:w-10 md:h-10 lg:w-12 lg:h-12 rounded-full bg-gradient-to-br from-nintendo-blue to-nintendo-purple flex items-center justify-center">
+              <div className="flex-shrink-0 w-8 h-8 md:w-10 md:h-10 lg:w-12 lg:h-12 rounded-full bg-gradient-to-br from-arcade-blue to-arcade-purple flex items-center justify-center">
                 {wasAnswerCorrect ? (
                   <Trophy className="h-4 w-4 md:h-5 md:w-5 lg:h-6 lg:w-6 text-white" />
                 ) : (
@@ -325,7 +325,7 @@ export default function QuestionCard() {
               </div>
               <div className="flex-1 space-y-1.5 md:space-y-2 lg:space-y-3">
                 <div className="flex items-center gap-2">
-                  <h3 className="text-heading font-bold text-nintendo-primary-text">
+                  <h3 className="text-heading font-bold text-arcade-primary-text">
                     {wasAnswerCorrect ? 'Correct!' : 'Not quite!'}
                   </h3>
                   {wasAnswerCorrect && (
@@ -333,13 +333,13 @@ export default function QuestionCard() {
                       initial={{ scale: 0 }}
                       animate={{ scale: 1 }}
                       transition={{ delay: 0.7, type: "spring", stiffness: 500, damping: 20 }}
-                      className="text-nintendo-green"
+                      className="text-arcade-green"
                     >
                       ✨
                     </motion.div>
                   )}
                 </div>
-                <p className="text-body text-nintendo-secondary-text leading-relaxed">
+                <p className="text-body text-arcade-secondary-text leading-relaxed">
                   {question.explanation}
                 </p>
               </div>

--- a/src/app/_components/ShowHeader.tsx
+++ b/src/app/_components/ShowHeader.tsx
@@ -15,11 +15,11 @@ export default function ShowHeader() {
         <div className="score-container-separated">
           <div className="score-item">
             <span className="text-caption">SCORE</span>
-            <span className="text-heading-xl text-nintendo-blue">{score}</span>
+            <span className="text-heading-xl text-arcade-blue">{score}</span>
           </div>
           <div className="score-item">
             <span className="text-caption">ACCURACY</span>
-            <span className="text-heading-xl text-nintendo-purple">{accuracyPercentage}%</span>
+            <span className="text-heading-xl text-arcade-purple">{accuracyPercentage}%</span>
           </div>
         </div>
       )}

--- a/src/app/_components/StartButton.tsx
+++ b/src/app/_components/StartButton.tsx
@@ -9,7 +9,7 @@ export default function StartButton() {
   return (
     <motion.button
       onClick={startGame}
-      className="nintendo-btn nintendo-btn-primary text-xl px-12 py-4"
+      className="arcade-btn arcade-btn-primary text-xl px-12 py-4"
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
       initial={{ opacity: 0, y: 20 }}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,28 +5,28 @@
 /* Import modern font pairings */
 @import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600;700&display=swap');
 
-/* Nintendo-Inspired Bright & Playful Design System */
+/* Apple Arcade-inspired sleek design system */
 :root {
-  --nintendo-red: #e60012;
-  --nintendo-blue: #0066cc;
-  --nintendo-yellow: #ffcc00;
-  --nintendo-green: #00a652;
-  --nintendo-purple: #8b5fbf;
-  --nintendo-orange: #ff6600;
-  --nintendo-pink: #ff69b4;
-  
+  --arcade-red: #ff453a;
+  --arcade-blue: #0a84ff;
+  --arcade-yellow: #ffd60a;
+  --arcade-green: #30d158;
+  --arcade-purple: #af52de;
+  --arcade-orange: #ff9f0a;
+  --arcade-pink: #ff2d55;
+
   /* Background colors */
-  --nintendo-bg-primary: #e8f4fd;
-  --nintendo-bg-secondary: #f0f8ff;
-  
+  --arcade-bg-primary: #1c1c1e;
+  --arcade-bg-secondary: #2c2c2e;
+
   /* Text colors */
-  --nintendo-primary-text: #1a365d;
-  --nintendo-secondary-text: #4a5568;
-  --nintendo-tertiary-text: #718096;
-  
+  --arcade-primary-text: #f2f2f7;
+  --arcade-secondary-text: #d1d1d6;
+  --arcade-tertiary-text: #8e8e93;
+
   /* Card colors */
-  --nintendo-card-bg: rgba(255, 255, 255, 0.95);
-  --nintendo-card-border: rgba(255, 255, 255, 0.6);
+  --arcade-card-bg: rgba(44, 44, 46, 0.8);
+  --arcade-card-border: rgba(255, 255, 255, 0.1);
   
   /* Spacing grid - 8pt system */
   --space-1: 0.125rem; /* 2px */
@@ -43,7 +43,7 @@
 
 /* Modern Typography System */
 .text-display-hero {
-  font-family: 'Sora', sans-serif;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif;
   font-size: 2.5rem; /* 40px */
   font-weight: 800;
   line-height: 1.1;
@@ -51,7 +51,7 @@
 }
 
 .text-display-lg {
-  font-family: 'Sora', sans-serif;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif;
   font-size: 2rem; /* 32px */
   font-weight: 700;
   line-height: 1.2;
@@ -59,53 +59,53 @@
 }
 
 .text-heading-xl {
-  font-family: 'Sora', sans-serif;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif;
   font-size: 1.5rem; /* 24px */
   font-weight: 700;
   line-height: 1.3;
 }
 
 .text-heading {
-  font-family: 'Sora', sans-serif;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif;
   font-size: 1.25rem; /* 20px */
   font-weight: 600;
   line-height: 1.3;
 }
 
 .text-body-lg {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   font-size: 1.125rem; /* 18px */
   font-weight: 600;
   line-height: 1.4;
 }
 
 .text-body {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   font-size: 1rem; /* 16px */
   font-weight: 500;
   line-height: 1.5;
-  color: var(--nintendo-primary-text);
+  color: var(--arcade-primary-text);
 }
 
 .text-small {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   font-size: 0.875rem; /* 14px */
   font-weight: 500;
   line-height: 1.4;
-  color: var(--nintendo-secondary-text);
+  color: var(--arcade-secondary-text);
 }
 
 .text-caption {
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   font-size: 0.75rem; /* 12px */
   font-weight: 500;
   line-height: 1.3;
-  color: var(--nintendo-tertiary-text);
+  color: var(--arcade-tertiary-text);
 }
 
 /* Question text - hero treatment */
 .text-question {
-  font-family: 'Sora', sans-serif;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif;
   font-size: 2.25rem; /* 36px */
   font-weight: 800;
   line-height: 1.3;
@@ -119,9 +119,10 @@
 
 /* Enhanced body styling - Static background */
 body {
-  font-family: 'Inter', sans-serif;
-  background: radial-gradient(ellipse at center, #87ceeb 0%, #4682b4 50%, #1e3a8a 100%);
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
+  background: linear-gradient(135deg, #1c1c1e 0%, #000000 100%);
   background-attachment: fixed;
+  color: var(--arcade-primary-text);
   min-height: 100vh;
   position: relative;
   overflow-x: hidden;
@@ -138,20 +139,20 @@ body::after {
 
 /* Enhanced logo with better contrast */
 .logo-text {
-  font-family: 'Sora', sans-serif;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif;
   font-size: 3rem;
   font-weight: 900;
   line-height: 0.9;
   letter-spacing: -0.05em;
-  background: linear-gradient(135deg, #ffffff 0%, #f0f8ff 50%, #ffffff 100%);
+  background: linear-gradient(135deg, var(--arcade-blue) 0%, var(--arcade-purple) 100%);
   background-size: 200% 200%;
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
-  text-shadow: 0 0 8px rgba(255, 255, 255, 0.4), 0 2px 4px rgba(255, 255, 255, 0.3);
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
   position: relative;
   display: inline-block;
-  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.3));
+  filter: drop-shadow(0 0 6px rgba(10, 132, 255, 0.3));
 }
 
 .logo-text::after {
@@ -162,18 +163,18 @@ body::after {
   transform: translateX(-50%);
   width: 60%;
   height: 3px;
-  background: linear-gradient(90deg, transparent, var(--nintendo-yellow), transparent);
+  background: linear-gradient(90deg, transparent, var(--arcade-yellow), transparent);
   border-radius: 2px;
 }
 
 /* Compact score container for top-right placement */
 .score-container-compact {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.8) 100%);
+  background: rgba(255, 255, 255, 0.06);
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;
   padding: var(--space-8) var(--space-12);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
   position: fixed;
   top: var(--space-8);
   right: var(--space-8);
@@ -202,14 +203,14 @@ body::after {
 }
 
 .score-item {
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(255, 255, 255, 0.06);
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;
   padding: var(--space-4) var(--space-6);
   text-align: center;
   min-width: 100px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
 /* Category chip styling */
@@ -217,16 +218,16 @@ body::after {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.7));
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 20px;
   padding: var(--space-2) var(--space-6);
   backdrop-filter: blur(8px);
-  font-family: 'Inter', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--nintendo-secondary-text);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  color: var(--arcade-secondary-text);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .category-chip-icon {
@@ -237,8 +238,8 @@ body::after {
 
 /* Enhanced answer cards with tactile design */
 .answer-card {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.85));
-  border: 2px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
   padding: var(--space-6) var(--space-8);
   cursor: pointer;
@@ -249,38 +250,38 @@ body::after {
 
 .answer-card:hover {
   transform: translateY(-2px) scale(1.01);
-  box-shadow: 
-    0 8px 24px rgba(0, 0, 0, 0.12),
-    0 4px 8px rgba(0, 0, 0, 0.06);
-  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.4),
+    0 4px 8px rgba(0, 0, 0, 0.2);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 .answer-card:active {
   transform: translateY(-1px) scale(1.005);
-  box-shadow: 
-    0 4px 12px rgba(0, 0, 0, 0.1),
-    0 2px 4px rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .answer-card-selected {
-  background: linear-gradient(135deg, rgba(0, 102, 204, 0.15), rgba(139, 95, 191, 0.15));
-  border-color: var(--nintendo-blue);
-  box-shadow: 
-    0 4px 16px rgba(0, 102, 204, 0.2),
-    0 2px 8px rgba(0, 102, 204, 0.1);
+  background: linear-gradient(135deg, rgba(10, 132, 255, 0.15), rgba(175, 82, 222, 0.15));
+  border-color: var(--arcade-blue);
+  box-shadow:
+    0 4px 16px rgba(10, 132, 255, 0.4),
+    0 2px 8px rgba(10, 132, 255, 0.2);
 }
 
 /* Answer card reveal states - full opacity colors */
 .answer-card-correct {
-  background: #00a652 !important;
-  border-color: #00a652 !important;
+  background: var(--arcade-green) !important;
+  border-color: var(--arcade-green) !important;
   color: white !important;
   animation: correctReveal 300ms ease-out;
 }
 
 .answer-card-incorrect {
-  background: #e60012 !important;
-  border-color: #e60012 !important;
+  background: var(--arcade-red) !important;
+  border-color: var(--arcade-red) !important;
   color: white !important;
   animation: incorrectShake 400ms ease-out;
 }
@@ -313,11 +314,11 @@ body::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: 'Sora', sans-serif;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif;
   font-size: 1rem;
   font-weight: 700;
   color: white;
-  background: linear-gradient(135deg, var(--nintendo-blue), var(--nintendo-purple));
+  background: linear-gradient(135deg, var(--arcade-blue), var(--arcade-purple));
   border: 2px solid rgba(255, 255, 255, 0.8);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   transition: all 200ms ease;
@@ -326,12 +327,12 @@ body::after {
 }
 
 .letter-badge-correct {
-  background: linear-gradient(135deg, var(--nintendo-green), #00d26a);
+  background: linear-gradient(135deg, var(--arcade-green), #00d26a);
   animation: badgeCorrect 300ms ease-out;
 }
 
 .letter-badge-incorrect {
-  background: linear-gradient(135deg, var(--nintendo-red), #ff4757);
+  background: linear-gradient(135deg, var(--arcade-red), #ff4757);
   animation: badgeIncorrect 400ms ease-out;
 }
 
@@ -347,34 +348,32 @@ body::after {
 }
 
 /* Nintendo card updates */
-.nintendo-card {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.85));
-  border: 2px solid rgba(255, 255, 255, 0.6);
+.arcade-card {
+  background: var(--arcade-card-bg);
+  border: 1px solid var(--arcade-card-border);
   border-radius: 20px;
   padding: 0 var(--space-8) var(--space-8) var(--space-8);
-  backdrop-filter: blur(12px);
-  box-shadow: 
-    0 8px 32px rgba(0, 0, 0, 0.1),
-    0 4px 16px rgba(0, 0, 0, 0.05);
+  backdrop-filter: blur(20px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   position: relative;
   overflow: hidden;
   transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.nintendo-card::before {
+.arcade-card::before {
   content: '';
   position: absolute;
   top: -1px;
   left: 0;
   right: 0;
   height: 4px;
-  background: linear-gradient(90deg, var(--nintendo-red), var(--nintendo-yellow), var(--nintendo-green), var(--nintendo-blue), var(--nintendo-purple));
+  background: linear-gradient(90deg, var(--arcade-blue), var(--arcade-purple));
   border-radius: 20px 20px 0 0;
 }
 
 /* Button enhancements */
-.nintendo-btn {
-  font-family: 'Inter', sans-serif;
+.arcade-btn {
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
   padding: var(--space-6) var(--space-12);
   font-size: 1rem;
   font-weight: 600;
@@ -386,28 +385,28 @@ body::after {
   overflow: hidden;
 }
 
-.nintendo-btn-primary {
-  background: linear-gradient(135deg, var(--nintendo-blue), var(--nintendo-purple));
+.arcade-btn-primary {
+  background: linear-gradient(135deg, var(--arcade-blue), var(--arcade-purple));
   color: white;
-  box-shadow: 0 4px 12px rgba(0, 102, 204, 0.3);
+  box-shadow: 0 4px 12px rgba(10, 132, 255, 0.4);
 }
 
-.nintendo-btn-primary:hover {
+.arcade-btn-primary:hover {
   transform: translateY(-1px) scale(1.02);
-  box-shadow: 0 6px 20px rgba(0, 102, 204, 0.4);
+  box-shadow: 0 6px 20px rgba(10, 132, 255, 0.6);
 }
 
-.nintendo-btn-secondary {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.8));
-  color: var(--nintendo-primary-text);
-  border: 2px solid rgba(255, 255, 255, 0.6);
+.arcade-btn-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--arcade-primary-text);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(8px);
 }
 
-.nintendo-btn-secondary:hover {
+.arcade-btn-secondary:hover {
   transform: translateY(-1px) scale(1.02);
-  border-color: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
 /* Mobile responsive adjustments */
@@ -456,25 +455,40 @@ body::after {
 }
 
 /* Color utilities */
-.text-nintendo-red { color: var(--nintendo-red); }
-.text-nintendo-blue { color: var(--nintendo-blue); }
-.text-nintendo-yellow { color: var(--nintendo-yellow); }
-.text-nintendo-green { color: var(--nintendo-green); }
-.text-nintendo-purple { color: var(--nintendo-purple); }
-.text-nintendo-orange { color: var(--nintendo-orange); }
-.text-nintendo-pink { color: var(--nintendo-pink); }
+.text-arcade-red { color: var(--arcade-red); }
+.text-arcade-blue { color: var(--arcade-blue); }
+.text-arcade-yellow { color: var(--arcade-yellow); }
+.text-arcade-green { color: var(--arcade-green); }
+.text-arcade-purple { color: var(--arcade-purple); }
+.text-arcade-orange { color: var(--arcade-orange); }
+.text-arcade-pink { color: var(--arcade-pink); }
 
-.bg-nintendo-red { background-color: var(--nintendo-red); }
-.bg-nintendo-blue { background-color: var(--nintendo-blue); }
-.bg-nintendo-yellow { background-color: var(--nintendo-yellow); }
-.bg-nintendo-green { background-color: var(--nintendo-green); }
-.bg-nintendo-purple { background-color: var(--nintendo-purple); }
-.bg-nintendo-orange { background-color: var(--nintendo-orange); }
-.bg-nintendo-pink { background-color: var(--nintendo-pink); }
+.bg-arcade-red { background-color: var(--arcade-red); }
+.bg-arcade-blue { background-color: var(--arcade-blue); }
+.bg-arcade-yellow { background-color: var(--arcade-yellow); }
+.bg-arcade-green { background-color: var(--arcade-green); }
+.bg-arcade-purple { background-color: var(--arcade-purple); }
+.bg-arcade-orange { background-color: var(--arcade-orange); }
+.bg-arcade-pink { background-color: var(--arcade-pink); }
+
+/* Gradient color utilities */
+.from-arcade-blue {
+  --tw-gradient-from: var(--arcade-blue) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(10 132 255 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+.to-arcade-purple {
+  --tw-gradient-to: var(--arcade-purple) var(--tw-gradient-to-position);
+}
+
+/* Text color helpers */
+.text-arcade-primary-text { color: var(--arcade-primary-text); }
+.text-arcade-secondary-text { color: var(--arcade-secondary-text); }
+.text-arcade-tertiary-text { color: var(--arcade-tertiary-text); }
 
 /* Focus ring */
 .focus-ring {
-  outline: 2px solid var(--nintendo-blue);
+  outline: 2px solid var(--arcade-blue);
   outline-offset: 2px;
 }
 
@@ -515,14 +529,15 @@ body::after {
   font-size: 0.875rem;
 }
 
+
 .score-blue {
-  color: var(--nintendo-blue);
-  text-shadow: 0 0 4px rgba(0, 102, 204, 0.4);
+  color: var(--arcade-blue);
+  text-shadow: 0 0 4px rgba(10, 132, 255, 0.4);
 }
 
 .score-purple {
-  color: var(--nintendo-purple);
-  text-shadow: 0 0 4px rgba(139, 95, 191, 0.4);
+  color: var(--arcade-purple);
+  text-shadow: 0 0 4px rgba(175, 82, 222, 0.4);
 }
 
 .score-text {
@@ -533,13 +548,13 @@ body::after {
 /* Mobile-specific score colors for better readability */
 .score-blue-mobile {
   color: #ffffff;
-  text-shadow: 0 0 6px rgba(0, 102, 204, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
+  text-shadow: 0 0 6px rgba(10, 132, 255, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
   font-weight: 700;
 }
 
 .score-purple-mobile {
   color: #ffffff;
-  text-shadow: 0 0 6px rgba(139, 95, 191, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
+  text-shadow: 0 0 6px rgba(175, 82, 222, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
   font-weight: 700;
 }
 
@@ -551,7 +566,7 @@ body::after {
 
 /* Enhanced Text-Question: THE HERO ELEMENT */
 .text-question {
-  font-family: 'Sora', sans-serif;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif;
   font-size: 2.75rem !important; /* Increased from 2.25rem for dominance */
   font-weight: 900 !important; /* Maximum impact */
   line-height: 1.1;
@@ -585,7 +600,7 @@ body::after {
 
 /* Refined Professional Logo */
 .logo-text {
-  font-family: 'Sora', sans-serif !important;
+  font-family: 'SF Pro Display', -apple-system, 'Sora', sans-serif !important;
   font-size: 2rem !important; /* Reduced from 3rem to be supporting */
   font-weight: 700 !important; /* Reduced from 900 for subtlety */
   line-height: 0.9;
@@ -632,8 +647,8 @@ body::after {
 }
 
 /* Enhanced next button text readability */
-.nintendo-btn-primary {
-  background: linear-gradient(135deg, var(--nintendo-red), var(--nintendo-orange));
+.arcade-btn-primary {
+  background: linear-gradient(135deg, var(--arcade-red), var(--arcade-orange));
   color: white;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
   font-weight: 600;


### PR DESCRIPTION
## Summary
- overhaul global theme with Apple Arcade-inspired palette and fonts
- restyle cards, buttons, and score display with sleek glassmorphism
- swap component class names to new arcade UI utilities

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e42552a08328b9d725b7b0ea100b