### PR TITLE
Revamp homepage with state-focused branding

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,16 @@
+<svg width="48" height="48" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <defs>
+    <linearGradient id="grad-left" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4f46e5"/>
+      <stop offset="100%" stop-color="#9333ea"/>
+    </linearGradient>
+    <linearGradient id="grad-right" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9333ea"/>
+      <stop offset="100%" stop-color="#ec4899"/>
+    </linearGradient>
+  </defs>
+  <rect x="2" y="16" width="20" height="20" rx="4" fill="url(#grad-left)"/>
+  <rect x="26" y="12" width="20" height="20" rx="4" fill="url(#grad-right)"/>
+  <text x="12" y="29" text-anchor="middle" font-size="10" font-family="'Sora', sans-serif" fill="white">CA</text>
+  <text x="36" y="25" text-anchor="middle" font-size="10" font-family="'Sora', sans-serif" fill="white">NY</text>
+</svg>

--- a/src/app/_components/GameBoard.tsx
+++ b/src/app/_components/GameBoard.tsx
@@ -20,19 +20,19 @@ export default function GameBoard() {
   if (gameState === 'idle') {
     return (
       <div className="w-full max-w-4xl mx-auto px-4">
-        <div className="nintendo-card text-center space-y-4 md:space-y-6 lg:space-y-8">
+        <div className="arcade-card text-center space-y-4 md:space-y-6">
           {/* Hero Section */}
-          <div className="space-y-3 md:space-y-4 lg:space-y-6">
+          <div className="space-y-3 md:space-y-4">
             <h2 className="text-display-lg md:text-display-hero text-white font-bold leading-tight">
-              Test Your Knowledge
+              Which State Comes Out on Top?
             </h2>
             <p className="text-body md:text-body-lg text-white/90 max-w-2xl mx-auto leading-relaxed px-4">
-              Compare facts across cities and states. Can you guess which location has more?
+              From population to education, guess which U.S. state has more.
             </p>
           </div>
-          
+
           {/* Category Grid */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 lg:gap-6 py-4 md:py-6 lg:py-8 mb-6 md:mb-8">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4 py-2 md:py-4 mb-4 md:mb-6">
             <div className="category-chip">
               <span className="category-chip-icon">👥</span>
               <span>Population</span>
@@ -89,7 +89,7 @@ export default function GameBoard() {
         >
           <button
             onClick={handleNextQuestion}
-            className="nintendo-btn nintendo-btn-primary"
+            className="arcade-btn arcade-btn-primary"
           >
             Next Question
           </button>

--- a/src/app/_components/QuestionCard.tsx
+++ b/src/app/_components/QuestionCard.tsx
@@ -282,7 +282,7 @@ export default function QuestionCard() {
                     )}
                   </div>
                   <div className="flex-1 text-left">
-                    <div className="text-body-lg font-semibold text-nintendo-primary-text">
+                    <div className="text-body-lg font-semibold text-arcade-primary-text">
                       {cleanedOption}
                     </div>
                     {isAnswered && (
@@ -292,7 +292,7 @@ export default function QuestionCard() {
                         transition={{ delay: 0.3 }}
                         className="mt-2"
                       >
-                        <div className="text-small text-nintendo-secondary-text">
+                        <div className="text-small text-arcade-secondary-text">
                           Value: {option.value?.toLocaleString()} {option.unit}
                         </div>
                       </motion.div>
@@ -314,9 +314,12 @@ export default function QuestionCard() {
           className="w-full mx-auto explanation-spacing"
           style={{maxWidth: '760px'}}
         >
-          <div className="nintendo-card text-left">
+          <div className="arcade-card text-left">
             <div className="flex items-start gap-3 md:gap-4">
-              <div className="flex-shrink-0 w-8 h-8 md:w-10 md:h-10 lg:w-12 lg:h-12 rounded-full bg-gradient-to-br from-nintendo-blue to-nintendo-purple flex items-center justify-center">
+              <div
+                className="flex-shrink-0 w-8 h-8 md:w-10 md:h-10 lg:w-12 lg:h-12 rounded-full flex items-center justify-center"
+                style={{ background: 'linear-gradient(to bottom right, var(--arcade-blue), var(--arcade-purple))' }}
+              >
                 {wasAnswerCorrect ? (
                   <Trophy className="h-4 w-4 md:h-5 md:w-5 lg:h-6 lg:w-6 text-white" />
                 ) : (
@@ -325,7 +328,7 @@ export default function QuestionCard() {
               </div>
               <div className="flex-1 space-y-1.5 md:space-y-2 lg:space-y-3">
                 <div className="flex items-center gap-2">
-                  <h3 className="text-heading font-bold text-nintendo-primary-text">
+                  <h3 className="text-heading font-bold text-arcade-primary-text">
                     {wasAnswerCorrect ? 'Correct!' : 'Not quite!'}
                   </h3>
                   {wasAnswerCorrect && (
@@ -333,13 +336,13 @@ export default function QuestionCard() {
                       initial={{ scale: 0 }}
                       animate={{ scale: 1 }}
                       transition={{ delay: 0.7, type: "spring", stiffness: 500, damping: 20 }}
-                      className="text-nintendo-green"
+                      className="text-arcade-green"
                     >
                       ✨
                     </motion.div>
                   )}
                 </div>
-                <p className="text-body text-nintendo-secondary-text leading-relaxed">
+                <p className="text-body text-arcade-secondary-text leading-relaxed">
                   {question.explanation}
                 </p>
               </div>

--- a/src/app/_components/ShowHeader.tsx
+++ b/src/app/_components/ShowHeader.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Image from 'next/image';
+import { Trophy, Target } from 'lucide-react';
 import { useGameStore } from '../_stores/gameStore';
 
 export default function ShowHeader() {
@@ -10,37 +12,48 @@ export default function ShowHeader() {
 
   return (
     <>
-      {/* Desktop Score Display - Top Right */}
+      {/* Desktop stats */}
       {gameState !== 'idle' && (
-        <div className="score-container-separated">
-          <div className="score-item">
-            <span className="text-caption">SCORE</span>
-            <span className="text-heading-xl text-nintendo-blue">{score}</span>
+        <div className="stats-floating">
+          <div className="stat-box">
+            <Trophy className="stat-icon text-arcade-blue" />
+            <div>
+              <div className="stat-label">Score</div>
+              <div className="stat-value">{score}</div>
+            </div>
           </div>
-          <div className="score-item">
-            <span className="text-caption">ACCURACY</span>
-            <span className="text-heading-xl text-nintendo-purple">{accuracyPercentage}%</span>
+          <div className="stat-box">
+            <Target className="stat-icon text-arcade-purple" />
+            <div>
+              <div className="stat-label">Accuracy</div>
+              <div className="stat-value">{accuracyPercentage}%</div>
+            </div>
           </div>
         </div>
       )}
 
-      {/* Main Title with inline score info for mobile */}
       <div className="w-full">
         <div className="text-center">
-          <h1 className="logo-text">
-            Who Has More?
-          </h1>
-          
-          {/* Inline score display for mobile only */}
+          <div className="flex items-center justify-center gap-3 mb-2">
+            <Image src="/logo.svg" alt="" width={40} height={40} />
+            <h1 className="logo-text">Who Has More?</h1>
+          </div>
+
           {gameState !== 'idle' && (
-            <div className="mobile-score-display">
-              <div className="score-inline">
-                <span className="score-label">Score:</span>
-                <span className="score-value score-blue-mobile">{score}</span>
+            <div className="stats-inline md:hidden">
+              <div className="stat-box">
+                <Trophy className="stat-icon text-arcade-blue" />
+                <div>
+                  <div className="stat-label">Score</div>
+                  <div className="stat-value">{score}</div>
+                </div>
               </div>
-              <div className="score-inline">
-                <span className="score-label">Accuracy:</span>
-                <span className="score-value score-purple-mobile">{accuracyPercentage}%</span>
+              <div className="stat-box">
+                <Target className="stat-icon text-arcade-purple" />
+                <div>
+                  <div className="stat-label">Accuracy</div>
+                  <div className="stat-value">{accuracyPercentage}%</div>
+                </div>
               </div>
             </div>
           )}
@@ -48,4 +61,4 @@ export default function ShowHeader() {
       </div>
     </>
   );
-} 
+}

--- a/src/app/_components/StartButton.tsx
+++ b/src/app/_components/StartButton.tsx
@@ -9,7 +9,7 @@ export default function StartButton() {
   return (
     <motion.button
       onClick={startGame}
-      className="nintendo-btn nintendo-btn-primary text-xl px-12 py-4"
+      className="arcade-btn arcade-btn-primary text-xl px-12 py-4"
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
       initial={{ opacity: 0, y: 20 }}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,29 +5,30 @@
 /* Import modern font pairings */
 @import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600;700&display=swap');
 
-/* Nintendo-Inspired Bright & Playful Design System */
+/* Apple Arcade inspired polished design system */
 :root {
-  --nintendo-red: #e60012;
-  --nintendo-blue: #0066cc;
-  --nintendo-yellow: #ffcc00;
-  --nintendo-green: #00a652;
-  --nintendo-purple: #8b5fbf;
-  --nintendo-orange: #ff6600;
-  --nintendo-pink: #ff69b4;
-  
+  /* Core palette */
+  --arcade-blue: #4f46e5;
+  --arcade-purple: #9333ea;
+  --arcade-pink: #ec4899;
+  --arcade-green: #10b981;
+  --arcade-red: #ef4444;
+  --arcade-orange: #f97316;
+  --arcade-yellow: #eab308;
+
   /* Background colors */
-  --nintendo-bg-primary: #e8f4fd;
-  --nintendo-bg-secondary: #f0f8ff;
-  
+  --arcade-bg-primary: #0f172a;
+  --arcade-bg-secondary: #1e293b;
+
   /* Text colors */
-  --nintendo-primary-text: #1a365d;
-  --nintendo-secondary-text: #4a5568;
-  --nintendo-tertiary-text: #718096;
-  
+  --arcade-primary-text: #f1f5f9;
+  --arcade-secondary-text: #cbd5e1;
+  --arcade-tertiary-text: #94a3b8;
+
   /* Card colors */
-  --nintendo-card-bg: rgba(255, 255, 255, 0.95);
-  --nintendo-card-border: rgba(255, 255, 255, 0.6);
-  
+  --arcade-card-bg: rgba(255, 255, 255, 0.08);
+  --arcade-card-border: rgba(255, 255, 255, 0.15);
+
   /* Spacing grid - 8pt system */
   --space-1: 0.125rem; /* 2px */
   --space-2: 0.25rem;  /* 4px */
@@ -84,7 +85,7 @@
   font-size: 1rem; /* 16px */
   font-weight: 500;
   line-height: 1.5;
-  color: var(--nintendo-primary-text);
+  color: var(--arcade-primary-text);
 }
 
 .text-small {
@@ -92,7 +93,7 @@
   font-size: 0.875rem; /* 14px */
   font-weight: 500;
   line-height: 1.4;
-  color: var(--nintendo-secondary-text);
+  color: var(--arcade-secondary-text);
 }
 
 .text-caption {
@@ -100,7 +101,7 @@
   font-size: 0.75rem; /* 12px */
   font-weight: 500;
   line-height: 1.3;
-  color: var(--nintendo-tertiary-text);
+  color: var(--arcade-tertiary-text);
 }
 
 /* Question text - hero treatment */
@@ -117,11 +118,13 @@
   text-align: center;
 }
 
-/* Enhanced body styling - Static background */
+/* Global body styling with rich arcade gradient */
 body {
   font-family: 'Inter', sans-serif;
-  background: radial-gradient(ellipse at center, #87ceeb 0%, #4682b4 50%, #1e3a8a 100%);
+  background: radial-gradient(circle at 20% 20%, var(--arcade-blue) 0%, var(--arcade-bg-primary) 80%);
+  background-color: var(--arcade-bg-primary);
   background-attachment: fixed;
+  color: var(--arcade-primary-text);
   min-height: 100vh;
   position: relative;
   overflow-x: hidden;
@@ -136,22 +139,21 @@ body::after {
   display: none;
 }
 
-/* Enhanced logo with better contrast */
+/* Clean title styling */
 .logo-text {
   font-family: 'Sora', sans-serif;
   font-size: 3rem;
   font-weight: 900;
   line-height: 0.9;
   letter-spacing: -0.05em;
-  background: linear-gradient(135deg, #ffffff 0%, #f0f8ff 50%, #ffffff 100%);
+  background: linear-gradient(135deg, var(--arcade-blue), var(--arcade-purple));
   background-size: 200% 200%;
-  background-clip: text;
   -webkit-background-clip: text;
+  background-clip: text;
   color: transparent;
-  text-shadow: 0 0 8px rgba(255, 255, 255, 0.4), 0 2px 4px rgba(255, 255, 255, 0.3);
+  text-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
   position: relative;
   display: inline-block;
-  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.3));
 }
 
 .logo-text::after {
@@ -160,56 +162,58 @@ body::after {
   bottom: -4px;
   left: 50%;
   transform: translateX(-50%);
-  width: 60%;
-  height: 3px;
-  background: linear-gradient(90deg, transparent, var(--nintendo-yellow), transparent);
+  width: 50%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--arcade-blue), var(--arcade-purple));
   border-radius: 2px;
+  opacity: 0.8;
 }
 
-/* Compact score container for top-right placement */
-.score-container-compact {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.8) 100%);
-  backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  border-radius: 12px;
-  padding: var(--space-8) var(--space-12);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  position: fixed;
-  top: var(--space-8);
-  right: var(--space-8);
-  z-index: 50;
-}
-
-/* Separated score containers */
-.score-container-separated {
-  display: flex;
-  gap: var(--space-4);
-  position: fixed;
-  top: var(--space-8);
-  right: var(--space-8);
-  z-index: 50;
-}
-
-/* Desktop score display - positioned on the right */
-.score-container-separated {
+/* Floating stat boxes used during play */
+.stats-floating {
   position: fixed;
   top: var(--space-4);
   right: var(--space-4);
   display: flex;
-  flex-direction: column;
   gap: var(--space-4);
-  z-index: 100;
+  z-index: 50;
 }
 
-.score-item {
-  background: rgba(255, 255, 255, 0.95);
+.stat-box {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 12px;
-  padding: var(--space-4) var(--space-6);
-  text-align: center;
-  min-width: 100px;
+  padding: var(--space-3) var(--space-4);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.stat-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  line-height: 1;
+  color: var(--arcade-tertiary-text);
+}
+
+.stat-value {
+  font-family: 'Sora', sans-serif;
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+.stats-inline {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
 }
 
 /* Category chip styling */
@@ -217,70 +221,65 @@ body::after {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.7));
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: var(--arcade-card-bg);
+  border: 1px solid var(--arcade-card-border);
   border-radius: 20px;
   padding: var(--space-2) var(--space-6);
   backdrop-filter: blur(8px);
   font-family: 'Inter', sans-serif;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--nintendo-secondary-text);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  color: var(--arcade-primary-text);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 
 .category-chip-icon {
   width: 16px;
   height: 16px;
-  opacity: 0.8;
 }
 
 /* Enhanced answer cards with tactile design */
 .answer-card {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.85));
-  border: 2px solid rgba(255, 255, 255, 0.6);
+  background: var(--arcade-card-bg);
+  border: 1px solid var(--arcade-card-border);
   border-radius: 16px;
   padding: var(--space-6) var(--space-8);
   cursor: pointer;
   transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   overflow: hidden;
+  backdrop-filter: blur(8px);
+  color: var(--arcade-primary-text);
 }
 
 .answer-card:hover {
   transform: translateY(-2px) scale(1.01);
-  box-shadow: 
-    0 8px 24px rgba(0, 0, 0, 0.12),
-    0 4px 8px rgba(0, 0, 0, 0.06);
-  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-color: rgba(255, 255, 255, 0.25);
 }
 
 .answer-card:active {
   transform: translateY(-1px) scale(1.005);
-  box-shadow: 
-    0 4px 12px rgba(0, 0, 0, 0.1),
-    0 2px 4px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .answer-card-selected {
-  background: linear-gradient(135deg, rgba(0, 102, 204, 0.15), rgba(139, 95, 191, 0.15));
-  border-color: var(--nintendo-blue);
-  box-shadow: 
-    0 4px 16px rgba(0, 102, 204, 0.2),
-    0 2px 8px rgba(0, 102, 204, 0.1);
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.15), rgba(147, 51, 234, 0.15));
+  border-color: var(--arcade-purple);
+  box-shadow: 0 4px 16px rgba(147, 51, 234, 0.3);
 }
 
 /* Answer card reveal states - full opacity colors */
 .answer-card-correct {
-  background: #00a652 !important;
-  border-color: #00a652 !important;
+  background: var(--arcade-green) !important;
+  border-color: var(--arcade-green) !important;
   color: white !important;
   animation: correctReveal 300ms ease-out;
 }
 
 .answer-card-incorrect {
-  background: #e60012 !important;
-  border-color: #e60012 !important;
+  background: var(--arcade-red) !important;
+  border-color: var(--arcade-red) !important;
   color: white !important;
   animation: incorrectShake 400ms ease-out;
 }
@@ -317,7 +316,7 @@ body::after {
   font-size: 1rem;
   font-weight: 700;
   color: white;
-  background: linear-gradient(135deg, var(--nintendo-blue), var(--nintendo-purple));
+  background: linear-gradient(135deg, var(--arcade-blue), var(--arcade-purple));
   border: 2px solid rgba(255, 255, 255, 0.8);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   transition: all 200ms ease;
@@ -326,12 +325,12 @@ body::after {
 }
 
 .letter-badge-correct {
-  background: linear-gradient(135deg, var(--nintendo-green), #00d26a);
+  background: linear-gradient(135deg, var(--arcade-green), #00d26a);
   animation: badgeCorrect 300ms ease-out;
 }
 
 .letter-badge-incorrect {
-  background: linear-gradient(135deg, var(--nintendo-red), #ff4757);
+  background: linear-gradient(135deg, var(--arcade-red), #ff4757);
   animation: badgeIncorrect 400ms ease-out;
 }
 
@@ -346,68 +345,66 @@ body::after {
   25%, 75% { transform: scale(1.05); }
 }
 
-/* Nintendo card updates */
-.nintendo-card {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.85));
-  border: 2px solid rgba(255, 255, 255, 0.6);
+/* Arcade card updates */
+.arcade-card {
+  background: var(--arcade-card-bg);
+  border: 1px solid var(--arcade-card-border);
   border-radius: 20px;
   padding: 0 var(--space-8) var(--space-8) var(--space-8);
   backdrop-filter: blur(12px);
-  box-shadow: 
-    0 8px 32px rgba(0, 0, 0, 0.1),
-    0 4px 16px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
   position: relative;
   overflow: hidden;
   transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.nintendo-card::before {
+.arcade-card::before {
   content: '';
   position: absolute;
   top: -1px;
   left: 0;
   right: 0;
-  height: 4px;
-  background: linear-gradient(90deg, var(--nintendo-red), var(--nintendo-yellow), var(--nintendo-green), var(--nintendo-blue), var(--nintendo-purple));
+  height: 3px;
+  background: linear-gradient(90deg, var(--arcade-blue), var(--arcade-purple));
   border-radius: 20px 20px 0 0;
 }
 
 /* Button enhancements */
-.nintendo-btn {
+.arcade-btn {
   font-family: 'Inter', sans-serif;
   padding: var(--space-6) var(--space-12);
   font-size: 1rem;
   font-weight: 600;
   border-radius: 12px;
   border: none;
-  transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
   cursor: pointer;
+  transition: transform 200ms, box-shadow 200ms;
   position: relative;
   overflow: hidden;
 }
 
-.nintendo-btn-primary {
-  background: linear-gradient(135deg, var(--nintendo-blue), var(--nintendo-purple));
-  color: white;
-  box-shadow: 0 4px 12px rgba(0, 102, 204, 0.3);
+.arcade-btn-primary {
+  background: linear-gradient(135deg, var(--arcade-blue), var(--arcade-purple));
+  color: #fff;
+  box-shadow: 0 4px 16px rgba(147, 51, 234, 0.4);
 }
 
-.nintendo-btn-primary:hover {
-  transform: translateY(-1px) scale(1.02);
-  box-shadow: 0 6px 20px rgba(0, 102, 204, 0.4);
+.arcade-btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(147, 51, 234, 0.5);
 }
 
-.nintendo-btn-secondary {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.8));
-  color: var(--nintendo-primary-text);
-  border: 2px solid rgba(255, 255, 255, 0.6);
+.arcade-btn-secondary {
+  background: var(--arcade-card-bg);
+  color: var(--arcade-primary-text);
+  border: 1px solid var(--arcade-card-border);
   backdrop-filter: blur(8px);
 }
 
-.nintendo-btn-secondary:hover {
-  transform: translateY(-1px) scale(1.02);
-  border-color: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+.arcade-btn-secondary:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.25);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 }
 
 /* Mobile responsive adjustments */
@@ -428,21 +425,7 @@ body::after {
     filter: drop-shadow(0 0 3px rgba(255, 255, 255, 0.3));
   }
   
-  .score-container-compact {
-    position: relative;
-    top: auto;
-    right: auto;
-    margin: var(--space-8) auto;
-  }
-  
-  .score-container-separated {
-    display: none; /* Hide desktop score display on mobile */
-  }
-  
-  .score-item {
-    min-width: 70px;
-    padding: var(--space-4) var(--space-6);
-  }
+  /* score container styles removed */
   
   .answer-card {
     padding: var(--space-6) var(--space-8);
@@ -456,97 +439,29 @@ body::after {
 }
 
 /* Color utilities */
-.text-nintendo-red { color: var(--nintendo-red); }
-.text-nintendo-blue { color: var(--nintendo-blue); }
-.text-nintendo-yellow { color: var(--nintendo-yellow); }
-.text-nintendo-green { color: var(--nintendo-green); }
-.text-nintendo-purple { color: var(--nintendo-purple); }
-.text-nintendo-orange { color: var(--nintendo-orange); }
-.text-nintendo-pink { color: var(--nintendo-pink); }
+.text-arcade-red { color: var(--arcade-red); }
+.text-arcade-blue { color: var(--arcade-blue); }
+.text-arcade-yellow { color: var(--arcade-yellow); }
+.text-arcade-green { color: var(--arcade-green); }
+.text-arcade-purple { color: var(--arcade-purple); }
+.text-arcade-orange { color: var(--arcade-orange); }
+.text-arcade-pink { color: var(--arcade-pink); }
+.text-arcade-primary-text { color: var(--arcade-primary-text); }
+.text-arcade-secondary-text { color: var(--arcade-secondary-text); }
+.text-arcade-tertiary-text { color: var(--arcade-tertiary-text); }
 
-.bg-nintendo-red { background-color: var(--nintendo-red); }
-.bg-nintendo-blue { background-color: var(--nintendo-blue); }
-.bg-nintendo-yellow { background-color: var(--nintendo-yellow); }
-.bg-nintendo-green { background-color: var(--nintendo-green); }
-.bg-nintendo-purple { background-color: var(--nintendo-purple); }
-.bg-nintendo-orange { background-color: var(--nintendo-orange); }
-.bg-nintendo-pink { background-color: var(--nintendo-pink); }
+.bg-arcade-red { background-color: var(--arcade-red); }
+.bg-arcade-blue { background-color: var(--arcade-blue); }
+.bg-arcade-yellow { background-color: var(--arcade-yellow); }
+.bg-arcade-green { background-color: var(--arcade-green); }
+.bg-arcade-purple { background-color: var(--arcade-purple); }
+.bg-arcade-orange { background-color: var(--arcade-orange); }
+.bg-arcade-pink { background-color: var(--arcade-pink); }
 
 /* Focus ring */
 .focus-ring {
-  outline: 2px solid var(--nintendo-blue);
+  outline: 2px solid var(--arcade-blue);
   outline-offset: 2px;
-}
-
-/* Mobile score display - inline with title */
-.mobile-score-display {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 1rem;
-  margin-top: 0.5rem;
-  flex-wrap: wrap;
-}
-
-/* Hide mobile score display on desktop */
-@media (min-width: 769px) {
-  .mobile-score-display {
-    display: none;
-  }
-}
-
-.score-inline {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.score-label {
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.score-value {
-  font-weight: 600;
-  font-size: 0.875rem;
-}
-
-.score-blue {
-  color: var(--nintendo-blue);
-  text-shadow: 0 0 4px rgba(0, 102, 204, 0.4);
-}
-
-.score-purple {
-  color: var(--nintendo-purple);
-  text-shadow: 0 0 4px rgba(139, 95, 191, 0.4);
-}
-
-.score-text {
-  color: rgba(255, 255, 255, 0.9);
-  text-shadow: 0 0 4px rgba(255, 255, 255, 0.3);
-}
-
-/* Mobile-specific score colors for better readability */
-.score-blue-mobile {
-  color: #ffffff;
-  text-shadow: 0 0 6px rgba(0, 102, 204, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
-  font-weight: 700;
-}
-
-.score-purple-mobile {
-  color: #ffffff;
-  text-shadow: 0 0 6px rgba(139, 95, 191, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
-  font-weight: 700;
-}
-
-.score-text-mobile {
-  color: #ffffff;
-  text-shadow: 0 0 6px rgba(255, 255, 255, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
-  font-weight: 700;
 }
 
 /* Enhanced Text-Question: THE HERO ELEMENT */
@@ -632,13 +547,7 @@ body::after {
 }
 
 /* Enhanced next button text readability */
-.nintendo-btn-primary {
-  background: linear-gradient(135deg, var(--nintendo-red), var(--nintendo-orange));
-  color: white;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
-  font-weight: 600;
-  box-shadow: 0 4px 12px rgba(230, 0, 18, 0.3);
-}
+/* Primary button styles defined above are reused here */
 
 /* Mobile responsive enhancements */
 @media (max-width: 768px) {
@@ -657,23 +566,6 @@ body::after {
     font-size: 1.5rem !important; /* Smaller on mobile to preserve question prominence */
     opacity: 0.8 !important;
     margin-bottom: 1rem !important; /* Reduced from 1.5rem */
-  }
-
-  .mobile-score-display {
-    gap: 0.75rem;
-    margin-top: 0.25rem;
-  }
-
-  .score-inline {
-    font-size: 0.75rem;
-  }
-
-  .score-label {
-    font-size: 0.625rem;
-  }
-
-  .score-value {
-    font-size: 0.75rem;
   }
 
   /* Make answer cards more compact on mobile */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,12 +9,14 @@ export default function Home() {
   const { showConfetti, showStarburst } = useGameStore();
 
   return (
-    <main className="min-h-screen relative">
+    <main className="h-screen relative flex flex-col overflow-hidden">
       <ConfettiEffect trigger={showConfetti} type="confetti" />
       <ConfettiEffect trigger={showStarburst} type="starburst" />
-      <div className="px-4 py-4 space-y-4 md:px-6 md:py-8 md:space-y-8">
+      <div className="flex flex-col flex-1 px-4 py-4 md:px-6 md:py-6">
         <ShowHeader />
-        <GameBoard />
+        <div className="flex-1 flex items-center justify-center">
+          <GameBoard />
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- highlight U.S. focus with new hero tagline and state comparison logo
- redesign score and accuracy boxes with glassy stat cards and icons
- center game layout to fit on a single screen across devices

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6898e42552a08328b9d725b7b0ea100b